### PR TITLE
Fix minor typos and do mild rephrasing in Solvers Introduction page

### DIFF
--- a/solvers/in-depth-solver-specification/introduction.md
+++ b/solvers/in-depth-solver-specification/introduction.md
@@ -1,5 +1,5 @@
 # Introduction
 
-The Cow Protocol uses batch auctions (see [here](../../overview/batch-auctions.md) for more details) for executing the trades. Within a given batch, the goal is to compute prices and traded amounts in order to maximize a well-defined utility function. This can be formulated as a concrete optimization problem that needs to be solved, and this is where the Solvers comes into place.
+CoW Protocol uses batch auctions (see [here](../../overview/batch-auctions.md) for more details) for executing the trades. Within a given batch, the goal is to compute prices and traded amounts in order to maximize a well-defined utility function. This can be formulated as a concrete optimization problem that needs to be solved, and this is where the Solvers comes into place.
 
-Informally, a _Solver_ is an algorithm that takes as input a batch auction instance and outputs a batch auction solution, both described precisely in a formal language. The solution is then processed by the _Driver_, another key component of the Cow Protocol infrastructure. The Driver validates all Solver candidate solutions and ranks them according to a well-defined objective function.
+Informally, a _Solver_ is an algorithm that takes as input a batch auction instance and outputs a batch auction solution, both described precisely in a formal language. The solution is then processed by the _Driver_, another key component of the CoW Protocol infrastructure. The Driver validates all Solver candidate solutions and ranks them according to a well-defined objective function.

--- a/solvers/solvers.md
+++ b/solvers/solvers.md
@@ -2,7 +2,7 @@
 
 ## Intent-based trading
 
-CoW protocol uses an intent-based trading model. Unlike on other DEXs, users on CoSwap don't execute their trades themselves. Instead of creating an Ethereum transaction for swapping token A for B (which costs gas, may fail, etc.) they sign an **intent** to trade the two tokens at a specified limit price.
+CoW protocol uses an intent-based trading model. Unlike on other DEXs, users on CoW Protocol do not execute their trades themselves. Instead of creating an Ethereum transaction for swapping token A for B (which costs gas, may fail, etc.) they sign an **intent** to trade the two tokens at a specified limit price.
 
 This intent is then handed off to third parties - the so-called **solvers** - who compete for the user's order flow by trying to give them the best possible price. The solver that offers the best execution price is granted the right to settle the user's order. The actual settlement transaction is then created and signed by the solver.
 
@@ -10,4 +10,4 @@ This intent is then handed off to third parties - the so-called **solvers** - wh
 
 Solvers can move tokens on behalf of the user (using the ERC20 approvals the user granted to the settlement contract) while the contract verifies the signature of the user's intent and that execution is done according to the limit price and quantity specified by the user.
 
-In the following sections we describe in more detail how the competition works today, provide a concrete guide on how to become a solver yourself and give an outlook on how we plan to fully decentralize this competition
+In the following sections we describe in more detail how the competition works today, provide a concrete guide on how to become a solver yourself and give an outlook on how we plan to fully decentralize this competition.


### PR DESCRIPTION
This PR fixes some very small typos and issues in the Solvers introduction page.

I think it's a good practice to start doing PRs for all meaningful changes we do in the docs (correcting a typo is not necessarily a meaningful change but I did this more as a test PR) , at least for the solver competition material, so that all solver teams can more easily keep track of those changes.