### PR TITLE
fix: cicd

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -7,6 +7,11 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+env:
+  BASE_URL: ${{ vars.BASE_URL }}
+  TRAILING_SLASH: ${{ vars.TRAILING_SLASH }}
+  URL: ${{ vars.URL }}
+
 jobs:
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
# Description
The environment for docusaurus isn't working in CI/CD. This fixes that.

# Changes

- [x] Correct the workflow to pull in the environment variables from the repository.